### PR TITLE
Move tests into require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,11 @@
   "license": "proprietary",
   "autoload": {
     "psr-4": {
-      "AppEngine\\TicketPicker\\": "src/",
+      "AppEngine\\TicketPicker\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
       "AppEngine\\TicketPicker\\Tests\\": "tests/"
     }
   },

--- a/composer.lock
+++ b/composer.lock
@@ -407,16 +407,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.74.0",
+            "version": "v3.75.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "6b7cb12a6cf592fd9a2b46a2d5d4c3b44003973d"
+                "reference": "399a128ff2fdaf4281e4e79b755693286cdf325c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/6b7cb12a6cf592fd9a2b46a2d5d4c3b44003973d",
-                "reference": "6b7cb12a6cf592fd9a2b46a2d5d4c3b44003973d",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/399a128ff2fdaf4281e4e79b755693286cdf325c",
+                "reference": "399a128ff2fdaf4281e4e79b755693286cdf325c",
                 "shasum": ""
             },
             "require": {
@@ -499,7 +499,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.74.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.75.0"
             },
             "funding": [
                 {
@@ -507,7 +507,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-27T22:31:30+00:00"
+            "time": "2025-03-31T18:40:42+00:00"
         },
         {
             "name": "myclabs/deep-copy",


### PR DESCRIPTION
This pull request includes a change to the `composer.json` file to add autoloading for development purposes. The change ensures that the `AppEngine\TicketPicker\Tests\` namespace is properly mapped to the `tests/` directory.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L8-R12): Added `autoload-dev` section to map the `AppEngine\TicketPicker\Tests\` namespace to the `tests/` directory.