### PR TITLE
Fix picker logic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "phpunit/phpunit": "^11.5",
     "phpstan/phpstan": "^2.0",
     "squizlabs/php_codesniffer": "^3.11",
-    "friendsofphp/php-cs-fixer": "^3.20"
+    "friendsofphp/php-cs-fixer": "^3.20",
+    "symfony/var-dumper": "^7.2"
   },
   "scripts": {
     "cs-fix": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix",
@@ -42,4 +43,3 @@
     ]
   }
 }
-

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2c26cb999d7ad433bf0b9d344dd9164",
+    "content-hash": "dae411a2ac664a7bcb0c836ded7378fb",
     "packages": [],
     "packages-dev": [
         {
@@ -4247,6 +4247,89 @@
                 }
             ],
             "time": "2024-11-13T13:31:26+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v7.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "82b478c69745d8878eb60f9a049a4d584996f73a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/82b478c69745d8878eb60f9a049a4d584996f73a",
+                "reference": "82b478c69745d8878eb60f9a049a4d584996f73a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/uid": "^6.4|^7.0",
+                "twig/twig": "^3.12"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v7.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-17T11:39:41+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Pickers/Picker.php
+++ b/src/Pickers/Picker.php
@@ -51,9 +51,11 @@ class Picker implements PickerInterface
 
         // For each character position, pick a random character from the unique candidates.
         do {
-            $pool = array_filter(
-                $sanitizedTickets,
-                static fn (string $code) => str_starts_with($code, $generatedCode),
+            $pool = array_values(
+                array_filter(
+                    $sanitizedTickets,
+                    static fn (string $code) => str_starts_with($code, $generatedCode),
+                ),
             );
 
             if (count($pool) === 1) {

--- a/tests/PickerTest.php
+++ b/tests/PickerTest.php
@@ -55,6 +55,31 @@ class PickerTest extends TestCase
     }
 
     /**
+     * @throws Exception
+     */
+    public function testGeneratedCodePicksCorrectlyWhenDifferentTicketsInPool(): void
+    {
+        $picker = $this->getMockBuilder(Picker::class)
+            ->onlyMethods(['getCharactersAtPosition'])
+            ->getMock();
+
+        $seed = 'random';
+        $pool = [
+            'ABCDEF',
+            'GHIJKL',
+            'MNOPQR',
+        ];
+
+        $picker->expects($this->once())
+            ->method('getCharactersAtPosition')
+            ->willReturn(['A', 'G', 'M']);
+
+        $code = $picker->generateCode($pool, $seed);
+
+        $this->assertEquals('GHIJKL', $code);
+    }
+
+    /**
      * @throws RandomException
      */
     public function testOnlyOneCodePicksTheFirstCode(): void

--- a/tests/PickerTest.php
+++ b/tests/PickerTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace AppEngine\TicketPicker\Tests;
 
 use AppEngine\TicketPicker\Exceptions\PickerException;
+use AppEngine\TicketPicker\Generators\Seed;
 use AppEngine\TicketPicker\Pickers\Picker;
 use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Random\RandomException;
 use ReflectionException;
 use ReflectionMethod;
 
@@ -51,6 +53,23 @@ class PickerTest extends TestCase
         $code = $picker->generateCode($pool, $seed);
 
         $this->assertEquals('ABCDEH', $code);
+    }
+
+    /**
+     * @throws RandomException
+     */
+    public function testOnlyOneCodePicksTheFirstCode(): void
+    {
+        $picker = new Picker();
+        $seed = (new Seed())->generateSeed();
+
+        $pool = [
+            'ABCDEF',
+        ];
+
+        $code = $picker->generateCode($pool, $seed);
+
+        $this->assertEquals('ABCDEF', $code);
     }
 
     /**

--- a/tests/PickerTest.php
+++ b/tests/PickerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace AppEngine\TicketPicker\Tests;
 
 use AppEngine\TicketPicker\Exceptions\PickerException;
-use AppEngine\TicketPicker\Generators\Seed;
 use AppEngine\TicketPicker\Pickers\Picker;
 use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -61,7 +60,7 @@ class PickerTest extends TestCase
     public function testOnlyOneCodePicksTheFirstCode(): void
     {
         $picker = new Picker();
-        $seed = (new Seed())->generateSeed();
+        $seed = 'test-seed';
 
         $pool = [
             'ABCDEF',


### PR DESCRIPTION
This pull request includes changes to the `Picker` class and its corresponding test cases to improve the code generation logic and add new test coverage. The most important changes include modifying the `generateCode` method to use `array_values` and adding a new test case to ensure the correct code is picked when only one code is available.

Improvements to code generation logic:

* [`src/Pickers/Picker.php`](diffhunk://#diff-258d505c162605f607dfddc3775ea1c51d213a93ca401832a710ea33ea3ad8afL54-R58): Modified the `generateCode` method to use `array_values` in conjunction with `array_filter` to ensure the pool array is re-indexed correctly and there is no error when attempting to access the first element with `0` key.

Enhancements to test coverage:

* [`tests/PickerTest.php`](diffhunk://#diff-4148293fc6584b6641a7faeaf6feabced48b9c3193918ef8c2e2ce134d69810bR8-R13): Added necessary imports for `Seed` and `RandomException` to support new test cases.
* [`tests/PickerTest.php`](diffhunk://#diff-4148293fc6584b6641a7faeaf6feabced48b9c3193918ef8c2e2ce134d69810bR58-R74): Added a new test case `testOnlyOneCodePicksTheFirstCode` to verify that the `generateCode` method correctly picks the code when there is only one code in the pool.